### PR TITLE
Rename tables in README, and smaller sleep

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This table will store information about the organizations.
 Note: The current limit is 500 organizations. This should be increased in future versions.
 
 ```
-create foreign table clerk_orgs (
+create foreign table clerk_organizations (
   organization_id text,
   name text,
   slug text,
@@ -75,7 +75,7 @@ options (
 This table connects the `clerk_users` and `clerk_orgs`. It lists out all users and their roles in each organization.
 
 ```
-create foreign table organization_memberships (
+create foreign table clerk_organization_memberships (
   user_id text,
   organization_id text,
   role text

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,8 +301,8 @@ impl ForeignDataWrapper for ClerkFdw {
                                             Err(_) => continue,
                                         };
 
-                                        // Introduce a delay of 0.5 seconds
-                                        std::thread::sleep(std::time::Duration::from_millis(500));
+                                        // Introduce a delay of 0.05 seconds
+                                        std::thread::sleep(std::time::Duration::from_millis(50));
                                     }
                                 }
                             }


### PR DESCRIPTION
I was thinking we'd use 50ms sleep not 500ms - 50ms should be enough

also changing README to use consistent naming in examples