### PR TITLE
Migrate to new self-hosted runners

### DIFF
--- a/.github/actions/pgx-init/action.yml
+++ b/.github/actions/pgx-init/action.yml
@@ -17,7 +17,7 @@ runs:
         chmod +x stoml
         sudo mv stoml /usr/local/bin/
         sudo apt update
-        sudo apt install -y build-essential pkg-config
+        sudo apt install -y build-essential pkg-config readline
     - name: setup pgrx
       shell: bash
       id: pgrx_install

--- a/.github/actions/pgx-init/action.yml
+++ b/.github/actions/pgx-init/action.yml
@@ -17,7 +17,7 @@ runs:
         chmod +x stoml
         sudo mv stoml /usr/local/bin/
         sudo apt update
-        sudo apt install -y icu
+        sudo apt install -y build-essential pkg-config
     - name: setup pgrx
       shell: bash
       id: pgrx_install

--- a/.github/actions/pgx-init/action.yml
+++ b/.github/actions/pgx-init/action.yml
@@ -16,8 +16,6 @@ runs:
         mv stoml_linux_amd64 stoml
         chmod +x stoml
         sudo mv stoml /usr/local/bin/
-        sudo apt update
-        sudo apt install -y build-essential pkg-config readline
     - name: setup pgrx
       shell: bash
       id: pgrx_install

--- a/.github/actions/pgx-init/action.yml
+++ b/.github/actions/pgx-init/action.yml
@@ -1,46 +1,47 @@
-name: 'pgrx initialization'
-description: 'Initialize PGRX if it is a dependency, otherwise do nothing.'
+name: "pgrx initialization"
+description: "Initialize PGRX if it is a dependency, otherwise do nothing."
 inputs:
   working-directory:
-    description: 'The directory in which there is a pgrx extension project'
+    description: "The directory in which there is a pgrx extension project"
     required: true
 outputs: {}
 runs:
   using: "composite"
   steps:
-      - name: Install TOML parser
-        shell: bash
-        run: |
-         set -xe
-         wget https://github.com/freshautomations/stoml/releases/download/v0.7.1/stoml_linux_amd64 &> /dev/null
-         mv stoml_linux_amd64 stoml
-         chmod +x stoml
-         sudo mv stoml /usr/local/bin/
-      - name: setup pgrx
-        shell: bash
-        id: pgrx_install
-        working-directory: ${{ inputs.working-directory }}
-        run: |
-          pgrx_version=$(stoml Cargo.toml dependencies.pgrx)
-          if [ -z "${pgrx_version}" ]; then
-            echo "pgrx is not a dependency: skipping"
-            echo "skip=true" >> $GITHUB_OUTPUT
-          else
-            cargo install --version ${pgrx_version} cargo-pgrx
-            echo "skip=false" >> $GITHUB_OUTPUT
-          fi
-      - name: pgrx init
-        shell: bash
-        if: steps.pgrx_install.outputs.skip == 'false'
-        working-directory: ${{ inputs.working-directory }}
-        run: |
-          set -x
-          pg_version=$(stoml Cargo.toml features.default)
-          # pgrx init can take a long time, and it re-compiles postgres even when there
-          # is a cached version. So, we can just check for the directory and
-          cat /home/runner/.pgrx/config.toml || true
-          if find /home/runner/.pgrx | grep $(awk -F "=" '/${pg_version}/ {print $2}' /home/runner/.pgrx/config.toml | tr -d '"'); then
-            echo "Already found pgrx is initialized. Skipping 'cargo pgrx init' command."
-          else
-            cargo pgrx init --${pg_version} download || true
-          fi
+    - name: Install TOML parser
+      shell: bash
+      run: |
+        set -xe
+        wget https://github.com/freshautomations/stoml/releases/download/v0.7.1/stoml_linux_amd64 &> /dev/null
+        mv stoml_linux_amd64 stoml
+        chmod +x stoml
+        sudo mv stoml /usr/local/bin/
+    - name: setup pgrx
+      shell: bash
+      id: pgrx_install
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        pgrx_version=$(stoml Cargo.toml dependencies.pgrx)
+        if [ -z "${pgrx_version}" ]; then
+          echo "pgrx is not a dependency: skipping"
+          echo "skip=true" >> $GITHUB_OUTPUT
+        else
+          cargo install --version ${pgrx_version} cargo-pgrx
+          echo "skip=false" >> $GITHUB_OUTPUT
+        fi
+    - name: pgrx init
+      shell: bash
+      if: steps.pgrx_install.outputs.skip == 'false'
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -x
+        apt update && apt install -y icu
+        pg_version=$(stoml Cargo.toml features.default)
+        # pgrx init can take a long time, and it re-compiles postgres even when there
+        # is a cached version. So, we can just check for the directory and
+        cat /home/runner/.pgrx/config.toml || true
+        if find /home/runner/.pgrx | grep $(awk -F "=" '/${pg_version}/ {print $2}' /home/runner/.pgrx/config.toml | tr -d '"'); then
+          echo "Already found pgrx is initialized. Skipping 'cargo pgrx init' command."
+        else
+          cargo pgrx init --${pg_version} download || true
+        fi

--- a/.github/actions/pgx-init/action.yml
+++ b/.github/actions/pgx-init/action.yml
@@ -16,6 +16,8 @@ runs:
         mv stoml_linux_amd64 stoml
         chmod +x stoml
         sudo mv stoml /usr/local/bin/
+        sudo apt update
+        sudo apt install -y icu
     - name: setup pgrx
       shell: bash
       id: pgrx_install
@@ -35,7 +37,6 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         set -x
-        apt update && apt install -y icu
         pg_version=$(stoml Cargo.toml features.default)
         # pgrx init can take a long time, and it re-compiles postgres even when there
         # is a cached version. So, we can just check for the directory and

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -21,6 +21,12 @@ jobs:
     name: Run linters
     runs-on: ubuntu-latest
     steps:
+      - name: Install package dependencies
+        shell: bash
+        run: |
+          set -x
+          sudo apt update
+          sudo apt install -y build-essential pkg-config libreadline-dev bison flex libclang-dev
       - uses: actions/checkout@v4
       - name: Install Rust nightly with clippy and rustfmt
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -19,19 +19,17 @@ on:
 jobs:
   lint:
     name: Run linters
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Install Rust minimal nightly with clippy and rustfmt
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - name: Install Rust nightly with clippy and rustfmt
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "clerk_fdw-extension-lint"
-          # Update cache directories as needed
+          cache: true
+          cache-key: "tembo-clerk_fdw-lint"
+          cache-on-failure: true
           cache-directories: |
             /home/runner/.pgrx
       - uses: ./.github/actions/pgx-init
@@ -54,10 +52,13 @@ jobs:
         uses: actions/checkout@v4
       - name: Start PostgreSQL ${{ matrix.pg }}
         run: pg-start ${{ matrix.pg }}
-      - name: Setup Rust Cache
-        uses: Swatinem/rust-cache@v2
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          cache: true
+          cache-key: "tembo-clerk_fdw-test"
+          cache-on-failure: true
       - name: Install pg_partman
         run: pgxn install pg_partman
       - name: Test on PostgreSQL ${{ matrix.pg }}
@@ -67,19 +68,19 @@ jobs:
     # only publish release events
     if: github.event_name == 'release'
     name: trunk publish
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         pg-version: [14, 15, 16, 17]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "clerk_fdw-extension-test"
+          cache: true
+          cache-key: "tembo-clerk_fdw-publish"
+          cache-on-failure: true
           cache-directories: |
             /home/runner/.pgrx
       - name: Install stoml and pg-trunk

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Cargo format
         run: cargo +nightly fmt --all --check
       - name: Clippy
-        run: cargo clippy
+        run: cargo clippy -- -W unexpected-cfgs
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -22,6 +22,12 @@ jobs:
     name: Upgrade Test
     runs-on: ubuntu-latest
     steps:
+      - name: Install package dependencies
+        shell: bash
+        run: |
+          set -x
+          sudo apt update
+          sudo apt install -y build-essential pkg-config libreadline-dev bison flex libclang-dev postgresql-server-dev-14
       - name: Checkout repository content
         uses: actions/checkout@v4
       - name: Install Rust stable toolchain
@@ -37,9 +43,6 @@ jobs:
         id: current-version
         run: echo "CI_BRANCH=$(git name-rev --name-only HEAD)" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/pgx-init
-      - name: Install sys dependencies
-        run: |
-          sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
       - name: Install and Test v0.3.0
         run: |
           git fetch --tags

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           set -x
           sudo apt update
-          sudo apt install -y build-essential pkg-config libreadline-dev bison flex libclang-dev postgresql-server-dev-14
+          sudo apt install -y build-essential pkg-config libreadline-dev bison flex libclang-dev postgresql-server-dev-16
       - name: Checkout repository content
         uses: actions/checkout@v4
       - name: Install Rust stable toolchain

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -1,4 +1,3 @@
-
 name: Extension Upgrade
 
 defaults:
@@ -21,18 +20,17 @@ on:
 jobs:
   test:
     name: Upgrade Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository content
         uses: actions/checkout@v4
       - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "extension-upgrade-test"
-          workspaces: clerk_fdw
+          cache: true
+          cache-key: "tembo-clerk_fdw-test"
+          cache-on-failure: true
           cache-directories: |
             /home/runner/.pgrx
       - name: Get current version

--- a/.github/workflows/pgxn-release.yml
+++ b/.github/workflows/pgxn-release.yml
@@ -2,7 +2,7 @@ name: 🚀 Release on PGXN
 on:
   push:
     # Release on semantic version tag.
-    tags: ['v[0-9]+.[0-9]+.[0-9]+']
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
 jobs:
   release:
     name: Release on PGXN

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,7 +371,7 @@ impl ForeignDataWrapper<ClerkFdwError> for ClerkFdw {
             if !result.is_empty() {
                 let scanned = result
                     .drain(0..1)
-                    .last()
+                    .next_back()
                     .map(|src_row| row.replace_with(src_row));
                 return Ok(scanned);
             }


### PR DESCRIPTION
Migrate the Github Actions CI workflow to use new self hosted runners from [runs-on](https://runs-on.com)